### PR TITLE
Wrap Long Lines

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -33,7 +33,7 @@ set shiftwidth=2
 set expandtab
 set smartindent
 set nofoldenable
-set nowrap
+set wrap linebreak nolist
 set smartcase
 set noswapfile
 set nobackup


### PR DESCRIPTION
I configured Vim to wrap long lines to fit in the window and not to split words into break lines.

## Summary by Sourcery

Enhancements:
- Configure Vim to wrap long lines and prevent word splitting by enabling 'wrap' and 'linebreak' options.